### PR TITLE
Update BaseDataObject.php

### DIFF
--- a/src/data_objects/BaseDataObject.php
+++ b/src/data_objects/BaseDataObject.php
@@ -12,7 +12,7 @@ abstract class BaseDataObject
 	{
 		$fieldVars = array();
 		foreach (get_object_vars($this) as $name => $value) {
-			if ($value) {
+			if (null !== $value) {
 				if ($value instanceof BaseDataObject) {
 					$fieldVars[$name] = $value->getParameters();
 				} else {


### PR DESCRIPTION
Это исправление позволит собирать объекты для запроса с корректным составом полей, например с нулевой ценой позиции в чеке, а не без неё вовсе (как сейчас, что приводит к ошибке при попытке создать такой чек)